### PR TITLE
Pass user emails to all LLMs

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/chat_backend.py
@@ -277,6 +277,7 @@ def handle_send_message_simple_with_history(
     rephrased_query = req.query_override or thread_based_query_rephrase(
         user_query=query,
         history_str=history_str,
+        user_email=user.email if user else None,
     )
 
     if req.retrieval_options is None and req.search_doc_ids is None:

--- a/backend/ee/onyx/server/query_and_chat/query_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/query_backend.py
@@ -63,7 +63,7 @@ def handle_search_request(
     query = search_request.message
     logger.notice(f"Received document search query: {query}")
 
-    llm, fast_llm = get_default_llms()
+    llm, fast_llm = get_default_llms(user_email=user.email if user else None)
 
     search_pipeline = SearchPipeline(
         search_request=SearchRequest(

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -45,7 +45,7 @@ def get_llms_for_persona(
 ) -> tuple[LLM, LLM]:
     if persona is None:
         logger.warning("No persona provided, using default LLMs")
-        return get_default_llms()
+        return get_default_llms(user_email=user_email)
 
     model_provider_override = llm_override.model_provider if llm_override else None
     model_version_override = llm_override.model_version if llm_override else None
@@ -55,6 +55,7 @@ def get_llms_for_persona(
     if not provider_name:
         return get_default_llms(
             temperature=temperature_override or GEN_AI_TEMPERATURE,
+            user_email=user_email,
             additional_headers=additional_headers,
             long_term_logger=long_term_logger,
         )

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -718,7 +718,7 @@ def build_request_details(
         if DANSWER_BOT_REPHRASE_MESSAGE:
             logger.info(f"Rephrasing Slack message. Original message: {msg}")
             try:
-                msg = rephrase_slack_message(msg)
+                msg = rephrase_slack_message(msg, user_email=email)
                 logger.info(f"Rephrased message: {msg}")
             except Exception as e:
                 logger.error(f"Error while trying to rephrase the Slack message: {e}")

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -87,7 +87,7 @@ def check_message_limit() -> bool:
     return True
 
 
-def rephrase_slack_message(msg: str) -> str:
+def rephrase_slack_message(msg: str, user_email: str | None = None) -> str:
     def _get_rephrase_message() -> list[dict[str, str]]:
         messages = [
             {
@@ -99,7 +99,7 @@ def rephrase_slack_message(msg: str) -> str:
         return messages
 
     try:
-        llm, _ = get_default_llms(timeout=5)
+        llm, _ = get_default_llms(timeout=5, user_email=user_email)
     except GenAIDisabledException:
         logger.warning("Unable to rephrase Slack user message, Gen AI disabled")
         return msg

--- a/backend/onyx/secondary_llm_flows/query_expansion.py
+++ b/backend/onyx/secondary_llm_flows/query_expansion.py
@@ -137,6 +137,7 @@ def thread_based_query_rephrase(
     llm: LLM | None = None,
     size_heuristic: int = 200,
     punctuation_heuristic: int = 10,
+    user_email: str | None = None,
 ) -> str:
     if not history_str:
         return user_query
@@ -149,7 +150,7 @@ def thread_based_query_rephrase(
 
     if llm is None:
         try:
-            llm, _ = get_default_llms()
+            llm, _ = get_default_llms(user_email=user_email)
         except GenAIDisabledException:
             # If Generative AI is turned off, just return the original query
             return user_query

--- a/backend/onyx/secondary_llm_flows/starter_message_creation.py
+++ b/backend/onyx/secondary_llm_flows/starter_message_creation.py
@@ -121,7 +121,7 @@ def generate_starter_messages(
     Generates starter messages by first obtaining categories and then generating messages for each category.
     On failure, returns an empty list (or list with processed starter messages if some messages are processed successfully).
     """
-    _, fast_llm = get_default_llms(temperature=0.5)
+    _, fast_llm = get_default_llms(temperature=0.5, user_email=user.email if user else None)
 
     provider = fast_llm.config.model_provider
     model = fast_llm.config.model_name

--- a/backend/onyx/server/gpts/api.py
+++ b/backend/onyx/server/gpts/api.py
@@ -65,10 +65,10 @@ class GptSearchResponse(BaseModel):
 @router.post("/gpt-document-search")
 def gpt_search(
     search_request: GptSearchRequest,
-    _: User | None = Depends(api_key_dep),
+    user: User | None = Depends(api_key_dep),
     db_session: Session = Depends(get_session),
 ) -> GptSearchResponse:
-    llm, fast_llm = get_default_llms()
+    llm, fast_llm = get_default_llms(user_email=user.email if user else None)
     top_sections = SearchPipeline(
         search_request=SearchRequest(
             query=search_request.query,

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -104,7 +104,7 @@ def document_hidden_update(
 
 @router.get("/admin/genai-api-key/validate")
 def validate_existing_genai_api_key(
-    _: User = Depends(current_admin_user),
+    user: User = Depends(current_admin_user),
 ) -> None:
     # Only validate every so often
     kv_store = get_kv_store()
@@ -121,7 +121,7 @@ def validate_existing_genai_api_key(
         pass
 
     try:
-        llm, __ = get_default_llms(timeout=10)
+        llm, __ = get_default_llms(timeout=10, user_email=user.email if user else None)
     except ValueError:
         raise HTTPException(status_code=404, detail="LLM not setup")
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -92,10 +92,10 @@ def test_llm_configuration(
 
 @admin_router.post("/test/default")
 def test_default_provider(
-    _: User | None = Depends(current_admin_user),
+    user: User | None = Depends(current_admin_user),
 ) -> None:
     try:
-        llm, fast_llm = get_default_llms()
+        llm, fast_llm = get_default_llms(user_email=user.email if user else None)
     except ValueError:
         logger.exception("Failed to fetch default LLM Provider")
         raise HTTPException(status_code=400, detail="No LLM Provider setup")

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -292,6 +292,7 @@ def rename_chat_session(
 
     try:
         llm, _ = get_default_llms(
+            user_email=user.email if user else None,
             additional_headers=extract_headers(
                 request.headers, LITELLM_PASS_THROUGH_HEADERS
             )
@@ -561,7 +562,7 @@ class ChatSeedResponse(BaseModel):
 def seed_chat(
     chat_seed_request: ChatSeedRequest,
     # NOTE: realistically, this will be an API key not an actual user
-    _: User | None = Depends(current_user),
+    user: User | None = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> ChatSeedResponse:
     try:
@@ -581,7 +582,10 @@ def seed_chat(
         root_message = get_or_create_root_message(
             chat_session_id=new_chat_session.id, db_session=db_session
         )
-        llm, fast_llm = get_llms_for_persona(persona=new_chat_session.persona)
+        llm, fast_llm = get_llms_for_persona(
+            persona=new_chat_session.persona,
+            user_email=user.email if user else None,
+        )
 
         tokenizer = get_tokenizer(
             model_name=llm.config.model_name,


### PR DESCRIPTION
We already pass user emails to any llms created using `get_llms_for_persona`. This PR extends the functionality to pass to _all_ llm factory methods.

If you want user emails to be passed to the llms which handle slack message authoring, document search etc etc, this is the PR you need.
